### PR TITLE
DEV: Merge route:users modifyClass into one

### DIFF
--- a/javascripts/discourse/initializers/user-card-directory.js.es6
+++ b/javascripts/discourse/initializers/user-card-directory.js.es6
@@ -16,10 +16,7 @@ export default {
             controller.set("cachedUserCardInfo", {});
           }
         },
-      });
 
-      api.modifyClass("route:users", {
-        pluginId: 'user-card-directory',
         queryParams: {
           cards: { refreshModel: true },
         },


### PR DESCRIPTION
Running modifyClass twice with the same pluginId means the second modification won't be applied. We can simply combine these two calls into one.