### PR TITLE
FIX: Regression after a core change

### DIFF
--- a/javascripts/discourse/initializers/user-card-directory.js
+++ b/javascripts/discourse/initializers/user-card-directory.js
@@ -11,6 +11,11 @@ export default {
       api.modifyClass("route:users", {
         pluginId: "user-card-directory",
 
+        init() {
+          this._super(...arguments);
+          this.queryParams.cards = { refreshModel: true };
+        },
+
         get templateName() {
           if (this.modelFor("users")?.showAsCards) {
             return "users-as-card-directory";
@@ -24,10 +29,6 @@ export default {
           if (isExiting) {
             controller.set("cachedUserCardInfo", {});
           }
-        },
-
-        queryParams: {
-          cards: { refreshModel: true },
         },
 
         model(params) {


### PR DESCRIPTION
https://github.com/discourse/discourse/commit/a3d0a9edbb74a403bb329a21d3387bf00aca0100 in core converted the Users route to a native class, which meant that `queryParams` merging no longer works.

Extend it manually in `init()`.