### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.4.0.beta2-dev: 533c97fc4fbf65310bdd7d3d13eebefddc4d5ffd
 < 3.4.0.beta1-dev: 195e853216558cdc16db598656619aa08abf8927
 < 3.3.0.beta1-dev: 4d7491226a4eac33f5a57ebd67f292ef91c8c51e
 3.1.999: 6942afd56f4cf43e643bbafe1782aa055fadc7bc

--- a/about.json
+++ b/about.json
@@ -8,6 +8,6 @@
   "assets": {},
   "color_schemes": {},
   "modifiers": {
-    "svg_icons": ["id-card", "th-list"]
+    "svg_icons": ["id-card", "table-list"]
   }
 }

--- a/javascripts/discourse/components/user-card-directory-toggle.gjs
+++ b/javascripts/discourse/components/user-card-directory-toggle.gjs
@@ -24,7 +24,7 @@ export default class UserCardDirectoryToggle extends Component {
   <template>
     <DButton
       @action={{this.toggleCards}}
-      @icon={{if this.showingCards "th-list" "id-card"}}
+      @icon={{if this.showingCards "table-list" "id-card"}}
       @title={{themePrefix (if this.showingCards "show_table" "show_cards")}}
       class="btn-default open-edit-columns-btn toggle-cards-button"
     />


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.