### PR TITLE
UX: consistent card heights, more space for stat labels

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -21,7 +21,7 @@
 .user-card-directory {
   display: grid;
   grid-template-columns: 1fr;
-  grid-gap: 60px 20px;
+  grid-gap: 100px 20px;
   margin-top: 60px;
 
   @media only screen and (min-width: 500px) {
@@ -29,11 +29,13 @@
   }
 
   .user-card-container {
-    margin: 60px 20px;
     margin-bottom: auto;
     width: 100%;
+    height: 100%;
     background-color: var(--secondary);
     box-shadow: var(--shadow-card);
+    display: flex;
+    flex-direction: column;
   }
 
   .user-card {
@@ -54,7 +56,8 @@
 
   .user-card-directory-footer {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(5em, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(7em, 1fr));
+    margin-top: auto;
     padding: 0.75em;
     background-color: var(--secondary);
     gap: 0.25em;


### PR DESCRIPTION
Labels overlapping reported here: https://meta.discourse.org/t/topics-created-replies-posted-slightly-overlap-in-user-card-view-of-the-user-directory/363690

This creates more wrapping, but it seems unavoidable 

Before:
![image](https://github.com/user-attachments/assets/c57985f1-8750-4ae9-aad4-5c14cb840eb1)




After:

![image](https://github.com/user-attachments/assets/29704f2f-6de8-483d-b4a1-da833f6f048b)



Mobile contents being offset reported here: https://meta.discourse.org/t/topics-created-replies-posted-slightly-overlap-in-user-card-view-of-the-user-directory/363690



Before:
![image](https://github.com/user-attachments/assets/39de86cf-0cb4-4551-88a7-42c80733a46d)

After:
![image](https://github.com/user-attachments/assets/effc0598-97d1-427e-bea0-a5e6b39ff239)